### PR TITLE
Fix task type for Play gradle example

### DIFF
--- a/src/main/paradox/index.md
+++ b/src/main/paradox/index.md
@@ -324,11 +324,11 @@ repositories {
     }
 }
 
-tasks.withType(ScalaCompile) {
+tasks.withType(PlatformScalaCompile) {
     scalaCompileOptions.additionalParameters = [
             "-Xplugin:" + configurations.lightbendFortifyPlugin.asPath,
             "-Xplugin-require:fortify",
-            "-P:fortify:build=play-webgoat"
+            "-P:fortify:build=myproject"
     ]
 }
 ```


### PR DESCRIPTION
Gradle Play plugin uses a different task type to compile Scala code:

https://docs.gradle.org/current/userguide/play_plugin.html#sec:play_tasks

See `compilePlayBinaryScala`. After this change, I can see `FortifyPlugin 1.0.2, licensed to ...` printed when running `./gradlew clean check`.