### PR TITLE
Tweak scala-fortify dependency definition

### DIFF
--- a/src/main/paradox/index.md
+++ b/src/main/paradox/index.md
@@ -119,7 +119,7 @@ Then, add the following to your top-level `build.sbt`:
 
 ```scala
 addCompilerPlugin(
-  "com.lightbend" %% "scala-fortify" % "1.0.10"
+  "com.lightbend" % "scala-fortify" % "1.0.10"
     classifier "assembly"
     cross CrossVersion.patch)
 scalacOptions += s"-P:fortify:build=myproject"


### PR DESCRIPTION
%% is for Scala binary version crossed dependencies (e.g _2.11). If this is specified to be patch version crossed (_2.11.12), this can just use %.

</bike-shed>